### PR TITLE
WI #77 Fix LSR executable packaging

### DIFF
--- a/Solution/TypeCobol.LanguageServerRobot/TypeCobol.LanguageServerRobot.csproj
+++ b/Solution/TypeCobol.LanguageServerRobot/TypeCobol.LanguageServerRobot.csproj
@@ -12,4 +12,10 @@
     <ProjectReference Include="..\TypeCobol.LanguageServer.Robot.Common\TypeCobol.LanguageServer.Robot.Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="TypeCobol.LanguageServerRobot.targets">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Solution/TypeCobol.LanguageServerRobot/TypeCobol.LanguageServerRobot.nuspec
+++ b/Solution/TypeCobol.LanguageServerRobot/TypeCobol.LanguageServerRobot.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>TypeCobol.LanguageServerRobot</id>
-		<version>1.5.0</version>
+		<version>1.5.1</version>
 		<authors>TypeCobol Team</authors>
 		<owners>TypeCobol Team</owners>
 		<!--<requireLicenseAcceptance>true</requireLicenseAcceptance>-->
@@ -20,6 +20,9 @@
 		</dependencies>
 	</metadata>
 	<files>
+		<file src=".\bin\Release\net6.0\TypeCobol.LanguageServerRobot.targets" target="build\TypeCobol.LanguageServerRobot.targets"/>
 		<file src=".\bin\Release\net6.0\TypeCobol.LanguageServerRobot.exe" target="lib\net6.0\TypeCobol.LanguageServerRobot.exe"/>
+		<file src=".\bin\Release\net6.0\TypeCobol.LanguageServerRobot.dll" target="lib\net6.0\TypeCobol.LanguageServerRobot.dll"/>
+		<file src=".\bin\Release\net6.0\TypeCobol.LanguageServerRobot.runtimeconfig.json" target="lib\net6.0\TypeCobol.LanguageServerRobot.runtimeconfig.json"/>
 	</files>
 </package>

--- a/Solution/TypeCobol.LanguageServerRobot/TypeCobol.LanguageServerRobot.targets
+++ b/Solution/TypeCobol.LanguageServerRobot/TypeCobol.LanguageServerRobot.targets
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<Content Include="$(MSBuildThisFileDirectory)..\lib\net6.0\TypeCobol.LanguageServerRobot.runtimeconfig.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+</Project>
+


### PR DESCRIPTION
In modern .NET, executables come as a portable dll along with a launcher (exe file) and a runtime-configuration file telling wich framework/runtime to use.

This PR modifies the NuGet produced in order to include these 3 files.
